### PR TITLE
Adicionar pipeline CI/CD com build, test e deploy

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -74,4 +74,3 @@ jobs:
       - name: Deploy para GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-git add .

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -1,0 +1,77 @@
+name: Deploy Vite para GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      - name: Setup do Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Build do projeto com Vite
+        run: npm run build
+
+      - name: Upload dos arquivos para deploy
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      - name: Setup nodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Instalar playwright runner
+        run: npx playwright install --with-deps
+
+      - name: Rodar testes
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+  deploy:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy para GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+git add .


### PR DESCRIPTION
Este pull request adiciona um workflow GitHub Actions com três jobs:

build: Gera os arquivos do projeto.

test: Executa testes automatizados.

deploy: Publica o conteúdo no GitHub Pages.

O pipeline é acionado automaticamente a cada push na branch main.